### PR TITLE
Add route to list models. 

### DIFF
--- a/app/backends/base.py
+++ b/app/backends/base.py
@@ -26,7 +26,7 @@ class LLMModel(BaseModel):
     id: str
     capability: Literal['chat', 'embedding']
 
-class BackendBase(ABC):
+class Backend(ABC):
     '''
     Subclasses of this represent AI service provides like Bedrock and Vertex.
     '''

--- a/app/backends/bedrock/bedrock.py
+++ b/app/backends/bedrock/bedrock.py
@@ -27,7 +27,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 from app.schema.open_ai import ChatCompletionRequest, EmbeddingRequest
-from app.backends.base import BackendBase, LLMModel
+from app.backends.base import Backend, LLMModel
 
 from .converse_conversions import (
     convert_open_ai_completion_bedrock, 
@@ -82,7 +82,7 @@ class BedrockModelsSettings(BaseSettings):
 # to ensure the correct instance handles requests. This is how the 
 # application knows which backends serve which models.
 
-class BedRockBackend(BackendBase):
+class BedRockBackend(Backend):
     class Settings(BaseSettings):
         model_config = SettingsConfigDict(env_file='.env',extra='ignore', env_file_encoding='utf-8', env_nested_delimiter="__" )
         bedrock_assume_role: str = Field(default=...)

--- a/app/backends/dependencies.py
+++ b/app/backends/dependencies.py
@@ -11,11 +11,11 @@ class Backend:
     def __call__(self, req: ChatCompletionRequest | EmbeddingRequest):
         model_id = req.model
 
-        backend, capability = BACKEND_MAP.get(model_id, (None, None))
+        backend, model = BACKEND_MAP.get(model_id, (None, None))
 
-        if not backend:
+        if not backend or not model:
             raise HTTPException(status_code=422, detail=f"Model '{model_id}' is not supported by this API.",)
-        elif capability != self.capability:
+        elif model.capability != self.capability:
             raise HTTPException(status_code=422, detail=f"This endpoint not does support {self.capability} with the model '{model_id}'.",)
 
         return backend

--- a/app/backends/vertex_ai/vertexai.py
+++ b/app/backends/vertex_ai/vertexai.py
@@ -8,7 +8,7 @@ from vertexai.generative_models import GenerativeModel, GenerationConfig
 from vertexai.language_models import TextEmbeddingModel, TextEmbedding
 
 from app.schema.open_ai import ChatCompletionRequest, ChatCompletionResponse, EmbeddingRequest
-from app.backends.base import BackendBase, LLMModel
+from app.backends.base import Backend, LLMModel
 
 from .conversions import (
     convert_vertex_response,
@@ -44,7 +44,7 @@ class VertexModelsSettings(BaseSettings):
     )
 
 
-class VertexBackend(BackendBase):
+class VertexBackend(Backend):
     class Settings(BaseSettings):
         model_config = SettingsConfigDict(env_file='.env',extra='ignore', env_file_encoding='utf-8', env_nested_delimiter="__" )
         vertex_project_id:str = Field(default=...)
@@ -104,5 +104,4 @@ class VertexBackend(BackendBase):
             parameters['output_dimensionality'] = payload.dimensions
             
         response: List[TextEmbedding] = await model.get_embeddings_async(**parameters)
-        print(response)
         return convert_vertex_embedding_response(response, model_id=payload.model)

--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -1,22 +1,22 @@
-from typing import Literal
+from typing import List
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
-from app.backends.base import BackendBase
+from app.backends.base import Backend, LLMModel
 from app.backends.bedrock.bedrock import BedRockBackend
 from app.backends.vertex_ai.vertexai import VertexBackend
 
 # Register backends
-backend_instances = [
+backend_instances: List[Backend]  = [
     BedRockBackend(),
     VertexBackend()
 ]
 
 # TODO revist this if we have more capabilities; this probably won't scale
-BACKEND_MAP:dict[str,tuple[BackendBase, Literal['chat', 'embedding']]] ={}
+BACKEND_MAP:dict[str,tuple[Backend, LLMModel]] ={}
 
 for backend in backend_instances:
     for model in backend.models:
-        BACKEND_MAP[model.id] = backend, model.capability
+        BACKEND_MAP[model.id] = backend, model
 
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file='.env', extra="ignore", env_file_encoding='utf-8', env_nested_delimiter="__" )

--- a/app/routers/api_v1.py
+++ b/app/routers/api_v1.py
@@ -1,11 +1,20 @@
+from typing import List
 from fastapi import APIRouter, Depends
 
 from app.auth.dependencies import RequiresScope
-from app.backends.dependencies import Backend
 from app.auth.schemas import Scope
+from app.backends.base import LLMModel
+from app.backends.dependencies import Backend
+from app.config.settings import BACKEND_MAP
 from app.schema.open_ai import ChatCompletionRequest, ChatCompletionResponse, EmbeddingRequest
 
 router = APIRouter()
+
+@router.get("/models")
+async def models(
+    api_key=Depends(RequiresScope([Scope.MODELS_EMBEDDING]))
+) -> List[LLMModel]:
+    return  [backend for _, backend in BACKEND_MAP.values()]
 
 
 @router.post("/chat")


### PR DESCRIPTION
This adds a route to list the models and capabilities available on the API.

Small refactors:
- `app.backends.base.BackendBase` renamed to `Backend` to make typing semantics more readable.
- Stores model schema on `BACKEND_MAP` rather than just capabilities so we have values we need for the route.