### PR TITLE
Change the authorization to use a bearer token

### DIFF
--- a/Example_Notebook/Example.ipynb
+++ b/Example_Notebook/Example.ipynb
@@ -1,8 +1,20 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "id": "77c33b81-3b86-42c4-ab32-f6eb948841ea",
+   "metadata": {},
+   "source": [
+    "\n",
+    "To run this notebook with `uv`, allowing it to pull in the dependencies from the project use:  \n",
+    "```\n",
+    "uv run --with jupyter jupyter lab\n",
+    "```"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 1,
    "id": "aaf6b83d-025e-470b-b400-fba96c4ca33e",
    "metadata": {},
    "outputs": [],
@@ -16,17 +28,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 2,
+   "id": "3d79a148-7331-42ab-86f6-ce63c5f7c7cd",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "env: api_key=testing_2jCgPibUYTtLQg\n"
+     ]
+    }
+   ],
+   "source": [
+    "%set_env api_key=testing_2jCgPibUYTtLQg"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
    "id": "736e8c9d-0132-4db0-9d55-4ed5aa9fdf52",
    "metadata": {},
    "outputs": [],
    "source": [
     "api_key = os.getenv('api_key')\n",
-    "endpoint = \"http://127.0.0.1:8000/api/v1/chat\"\n",
+    "endpoint = \"http://127.0.0.1:8000/api/v1/chat/completions\"\n",
     "\n",
     "headers = {\n",
     "    'accept': 'application/json',\n",
-    "    'X-API-Key': api_key,\n",
+    "    'authorization': f'Bearer {api_key}',\n",
     "    'Content-Type': 'application/json'\n",
     "}"
    ]
@@ -41,7 +71,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": 4,
    "id": "c823a5d0-0270-47c6-9601-ddbe0ac44cfd",
    "metadata": {},
    "outputs": [],
@@ -63,17 +93,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 5,
    "id": "b328156b-f1de-41fe-9ce8-44140424ed2e",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "\"Yarr matey! *adjusts eye patch* A fine day fer greetin's! What brings ye to these waters, landlubber?\""
+       "'Yarr! Ahoy there, matey! *adjusts eye patch* What brings ye to these waters today? Be ye friend or foe?'"
       ]
      },
-     "execution_count": 63,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -99,7 +129,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 6,
    "id": "3a062e44-e00c-4f13-97fe-323b02558092",
    "metadata": {},
    "outputs": [
@@ -110,7 +140,7 @@
        "<IPython.core.display.Image object>"
       ]
      },
-     "execution_count": 49,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -123,7 +153,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 7,
    "id": "d0922633-5e53-4119-ac3f-56189786e351",
    "metadata": {},
    "outputs": [
@@ -134,7 +164,7 @@
        "<IPython.core.display.Image object>"
       ]
      },
-     "execution_count": 50,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -145,7 +175,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 8,
    "id": "62ff091b-1311-4430-9fd8-3544d3b1877d",
    "metadata": {},
    "outputs": [],
@@ -194,7 +224,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 9,
    "id": "3d045212-a985-4d69-ac69-3d902ac7fccd",
    "metadata": {},
    "outputs": [
@@ -202,10 +232,10 @@
      "data": {
       "text/plain": [
        "{'is_correct': False,\n",
-       " 'description': \"Cartoon image of a computer with a displeased expression inside a seal that says 'Office of Unspecified Services'.\"}"
+       " 'description': 'Cartoon seal of the Office of Unspecified Services featuring a computer with a face.'}"
       ]
      },
-     "execution_count": 55,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/app/routers/api_v1.py
+++ b/app/routers/api_v1.py
@@ -18,7 +18,7 @@ async def models(
     return  [backend for _, backend in settings.backend_map.values()]
 
 
-@router.post("/chat")
+@router.post("/chat/completions")
 async def converse(
     req: ChatCompletionRequest, 
     api_key=Depends(RequiresScope([Scope.MODELS_INFERENCE])),

--- a/app/schema/open_ai.py
+++ b/app/schema/open_ai.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field, confloat, ConfigDict, NonNegativeInt
+from pydantic import BaseModel, Field, confloat, ConfigDict, NonNegativeInt, field_serializer
 from typing import Literal, Optional, Union, List, Annotated
 from datetime import datetime
 
@@ -124,7 +124,10 @@ class ChatCompletionResponse(BaseModel):
     model: str
     choices: List[ChatCompletionChoice]
     usage: ChatCompletionUsage
-
+    
+    @field_serializer('created')
+    def serialize_dt(self, created: datetime, _info):
+        return int(created.timestamp())
 
 ### Embedding Requests Models ###
 # This is not used at the moment — it's not clear how to convert to Bedrock's Cohere model

--- a/tests/unit/auth/test_authentication.py
+++ b/tests/unit/auth/test_authentication.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 from unittest.mock import AsyncMock  
 
 from fastapi import HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials
 from app.auth.dependencies import valid_api_key
 from app.auth.schemas import APIKeyOut
 
@@ -15,11 +16,11 @@ API_KEY_REPOSITORY_PATH = "app.auth.dependencies.APIKeyRepository"
 pytestmark = pytest.mark.asyncio
 
 @pytest.fixture(scope="module") 
-def api_key():
+def api_key() -> HTTPAuthorizationCredentials:
     # the unit under test does not validate the api key
     # but we'll use it to make sure it's passing to the 
     # repository correctly
-    return "testing_abc123"
+    return HTTPAuthorizationCredentials(scheme="Bearer", credentials='testing_abc123')
 
 @pytest.fixture(scope="module") 
 def good_api_key():
@@ -90,10 +91,10 @@ async def test_passes_api_key_to_repo(mocker, good_api_key, api_key):
         return_value=mock_api_key_repo 
     )
 
-    await valid_api_key(api_key_header=api_key, session=mock_session)
+    await valid_api_key(credentials=api_key, session=mock_session)
 
     mock_api_key_repository_class.assert_called_once_with(mock_session)
-    mock_api_key_repo.get_by_api_key_value.assert_awaited_once_with(api_key)
+    mock_api_key_repo.get_by_api_key_value.assert_awaited_once_with(api_key.credentials)
 
 
 async def test_get_api_key_valid_key(mocker, good_api_key, api_key):
@@ -110,7 +111,7 @@ async def test_get_api_key_valid_key(mocker, good_api_key, api_key):
         return_value=mock_api_key_repo 
     )
 
-    returned_key = await valid_api_key(api_key_header=api_key, session=mock_session)
+    returned_key = await valid_api_key(credentials=api_key, session=mock_session)
 
     assert returned_key == good_api_key
     assert returned_key.is_active is True
@@ -131,7 +132,7 @@ async def test_get_token_inactive_key(mocker, inactive_api_key, api_key):
     )
 
     with pytest.raises(HTTPException) as exc_info:
-        await valid_api_key(api_key_header=api_key, session=mock_session)
+        await valid_api_key(credentials=api_key, session=mock_session)
 
     assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
     assert "Missing or invalid API key" in exc_info.value.detail
@@ -152,7 +153,7 @@ async def test_get_token_expired_token(mocker, expired_api_key, api_key):
     )
 
     with pytest.raises(HTTPException) as exc_info:
-        await valid_api_key(api_key_header=api_key, session=mock_session)
+        await valid_api_key(credentials=api_key, session=mock_session)
 
     assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
     assert "API key is expired" in exc_info.value.detail
@@ -171,7 +172,7 @@ async def test_get_token_non_expired_token(mocker, non_expired_api_key, api_key)
         return_value=mock_api_key_repo 
     )
 
-    returned_api_key = await valid_api_key(api_key_header=api_key, session=mock_session)
+    returned_api_key = await valid_api_key(credentials=api_key, session=mock_session)
 
     assert returned_api_key == non_expired_api_key
     assert returned_api_key.is_active is True


### PR DESCRIPTION
Using the `x-api-key header` for auth was a quick way to get things working, but is probably the wrong choice for something based on OpenAI. Other tooling, especially LangChain, will expect to provide auth in the authorization header as a bearer token.

This also changes the serialization for chat created date to an integer — pydantic serializes to a string by default, which caused warnings from LangChain, which is correct based on the OpenAI spec.